### PR TITLE
fix: sync decoder impl access

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -142,8 +142,8 @@ func (t *DecodeInstructionLookup) add(hash []byte, field []decodeInstruction, id
 
 // get performs the lookup on the supplied hash
 func (t *DecodeInstructionLookup) get(hash []byte) ([]decodeInstruction, bool) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
+	t.mu.RLock()
+	defer t.mu.RUnlock()
 
 	node := &t.root
 	var i int

--- a/decoder_race_test.go
+++ b/decoder_race_test.go
@@ -1,0 +1,39 @@
+package glint
+
+import (
+	"sync"
+	"testing"
+)
+
+type simpleStruct struct {
+	A int    `glint:"a"`
+	B string `glint:"b"`
+}
+
+func TestDecoderConcurrentUnmarshalRace(t *testing.T) {
+	enc := NewEncoder[simpleStruct]()
+	dec := NewDecoder[simpleStruct]()
+
+	original := simpleStruct{A: 42, B: "hello"}
+	buf := NewBufferFromPool()
+	defer buf.ReturnToPool()
+
+	enc.Marshal(&original, buf)
+	b := buf.Bytes
+
+	f := func(b []byte, wg *sync.WaitGroup) {
+		defer wg.Done()
+		var s simpleStruct
+		for j := 0; j < 100; j++ {
+			_ = dec.Unmarshal(b, &s)
+		}
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go f(b, &wg)
+	go f(b, &wg)
+
+	wg.Wait()
+}

--- a/glint.go
+++ b/glint.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 	"unsafe"
 )
@@ -271,7 +272,8 @@ func (t TrustHeader) Value() string {
 // NewTrustHeader creates an HTTP header for schema trust negotiation.
 // Use with NewBufferWithTrust to skip schema transmission when both sides have matching schemas.
 func NewTrustHeader(d *decoderImpl) TrustHeader {
-	return TrustHeader{"X-Glint-Trust", strconv.FormatUint(uint64(d.lastHash), 10)}
+	lastHash := atomic.LoadUint32(&d.lastHash)
+	return TrustHeader{"X-Glint-Trust", strconv.FormatUint(uint64(lastHash), 10)}
 }
 
 // deref creates a wrapper that dereferences pointers and handles nil checks.


### PR DESCRIPTION
# Description
- Fixes #1 

# Changes
- Atomically loading and storing `d.lastHash`.
- Synchronising the DecodeInstructionLookup trie with a mutex.

